### PR TITLE
Added better support for Oracle Db

### DIFF
--- a/src/MiniSqlQuery.Core/DatabaseMetaDataService.cs
+++ b/src/MiniSqlQuery.Core/DatabaseMetaDataService.cs
@@ -27,7 +27,7 @@ namespace MiniSqlQuery.Core
 		/// The default is <see cref = "GenericSchemaService" />.
 		/// </returns>
 		public static IDatabaseSchemaService Create(string providerName)
-		{
+		{            
 			switch (providerName)
 			{
 				case "System.Data.OleDb":
@@ -35,7 +35,8 @@ namespace MiniSqlQuery.Core
 
 				case "System.Data.SqlClient":
 					return new SqlClientSchemaService {ProviderName = providerName};
-
+                case "Oracle.DataAccess.Client":
+                    return new OracleSchemaService { ProviderName = providerName };
 				default:
 					// The SQL CE types tend to include the version number within the provider name, hence "StartsWith"
 					if (providerName.StartsWith("System.Data.SqlServerCe."))

--- a/src/MiniSqlQuery.Core/DbModel/GenericSchemaService.cs
+++ b/src/MiniSqlQuery.Core/DbModel/GenericSchemaService.cs
@@ -35,6 +35,7 @@ namespace MiniSqlQuery.Core.DbModel
 		/// <returns>An instance of <see cref="DbModelInstance"/> describing the database.</returns>
 		public virtual DbModelInstance GetDbObjectModel(string connection)
 		{
+
 			_connection = connection;
 
 			DbModelInstance model = new DbModelInstance();
@@ -303,16 +304,27 @@ namespace MiniSqlQuery.Core.DbModel
 		/// <param name="row">The row.</param>
 		/// <param name="columnName">The column name.</param>
 		/// <returns>The safe get int.</returns>
-		protected int SafeGetInt(DataRow row, string columnName)
+		protected virtual int SafeGetInt(DataRow row, string columnName)
 		{
-			int result = -1;
+            try
+            {
+                int result = -1;
 
-			if (row.Table.Columns.Contains(columnName) && !row.IsNull(columnName))
-			{
-				result = Convert.ToInt32(row[columnName]);
-			}
+                if (row.Table.Columns.Contains(columnName) && !row.IsNull(columnName))
+                {
+                    result = Convert.ToInt32(row[columnName]);
+                }
 
-			return result;
+                return result;
+            }
+            catch (OverflowException err)
+            {
+                // In Oracle Maximum size for column is larger than Max Int32, instead of changing return value, just coerce on Max.Int32.
+
+                return Int32.MaxValue;
+                
+            }
+
 		}
 
 		/// <summary>The safe get string.</summary>

--- a/src/MiniSqlQuery.Core/DbModel/OracleSchemaService.cs
+++ b/src/MiniSqlQuery.Core/DbModel/OracleSchemaService.cs
@@ -1,0 +1,103 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Data.Common;
+using System.Linq;
+using System.Text;
+
+namespace MiniSqlQuery.Core.DbModel
+{
+    public class OracleSchemaService : GenericSchemaService
+    {
+
+        protected override int SafeGetInt(DataRow row, string columnName)
+        {
+            try
+            {
+                return base.SafeGetInt(row, columnName);
+            }
+            catch (OverflowException)
+            { 
+                // Coerce to Max.Int32
+                return Int32.MaxValue;
+            }
+        }
+
+        public override DbModelInstance GetDbObjectModel(string connection)
+        {
+
+            //_connection = connection;
+
+            DbModelInstance model = new DbModelInstance();
+            DbProviderFactory factory = DbProviderFactories.GetFactory(ProviderName);
+
+            using (DbConnection dbConn = factory.CreateConnection())
+            {
+                dbConn.ConnectionString = connection;
+                dbConn.Open();
+
+                DataTable tables = dbConn.GetSchema("Tables");
+                Dictionary<string, DbModelType> dbTypes = GetDbTypes(dbConn);
+                model.Types = dbTypes;
+                model.ProviderName = ProviderName;
+                model.ConnectionString = connection;
+
+                if (tables == null)
+                {
+                    return model;
+                }
+
+                DataView tablesDV = new DataView(tables, "", "OWNER, TABLE_NAME", DataViewRowState.CurrentRows);
+
+                foreach (DataRowView row in tablesDV)
+                {
+                    string schemaName = SafeGetString(row.Row, "OWNER");
+                    string tableName = SafeGetString(row.Row, "TABLE_NAME");
+
+                    DbModelTable dbTable = new DbModelTable { Schema = schemaName, Name = tableName };
+                    model.Add(dbTable);
+
+                    DataTable schemaTableKeyInfo = GetTableKeyInfo(dbConn, schemaName, tableName);
+                    GetColumnsForTable(dbTable, schemaTableKeyInfo, dbTypes);
+                }
+
+                DataTable views = dbConn.GetSchema("Views");
+                DataView viewsDV = new DataView(views, "", "OWNER, VIEW_NAME", DataViewRowState.CurrentRows);
+                foreach (DataRowView row in viewsDV)
+                {
+                    string schemaName = SafeGetString(row.Row, "OWNER");
+                    string tableName = SafeGetString(row.Row, "VIEW_NAME");
+
+                    DbModelView dbTable = new DbModelView { Schema = schemaName, Name = tableName };
+                    model.Add(dbTable);
+
+                    DataTable schemaTableKeyInfo = GetTableKeyInfo(dbConn, schemaName, tableName);
+                    GetColumnsForTable(dbTable, schemaTableKeyInfo, dbTypes);
+                }
+
+                // build FK relationships 
+                if (model.Tables != null)
+                {
+                    foreach (DbModelTable table in model.Tables)
+                    {
+                        GetForeignKeyReferencesForTable(dbConn, table);
+                        ProcessForeignKeyReferencesForTable(dbConn, table);
+                    }
+                }
+
+                // build FK relationships
+                if (model.Views != null)
+                {
+                    foreach (DbModelView view in model.Views)
+                    {
+                        GetForeignKeyReferencesForTable(dbConn, view);
+                        ProcessForeignKeyReferencesForTable(dbConn, view);
+                    }
+                }
+            }
+
+            return model;
+        }
+
+    }
+}

--- a/src/MiniSqlQuery.Core/MiniSqlQuery.Core.csproj
+++ b/src/MiniSqlQuery.Core/MiniSqlQuery.Core.csproj
@@ -165,6 +165,7 @@
     <Compile Include="DbModel\GenericSchemaService.cs" />
     <Compile Include="DbModel\ISqlWriter.cs" />
     <Compile Include="DbModel\OleDbSchemaService.cs" />
+    <Compile Include="DbModel\OracleSchemaService.cs" />
     <Compile Include="DbModel\SqlCeSchemaService.cs" />
     <Compile Include="DbModel\SqlClientSchemaService.cs" />
     <Compile Include="DbModel\SqlWriter.cs" />


### PR DESCRIPTION
Hi, i've noticed that when using MiniSqlQuery against Oracle databases, a annoying Overflow exception was thrown and DbInspector was not working.

I've noticed that the problem was due to the method trying to check type maximum size (SafeGetInt): since in Oracle maximum size of types (i.e. blob) can be 4GB it immediately throws an overflow.

The fix was to add a try/catch and, in case the exception is an Overflow, just trap it coercing the return value to Int32.Max.

This didn't make the program work correctly but simply changed the exception thrown, the second problem was that Oracle tables don't have the structure expected by the GenericSchemaService class (TABLE_TYPE does not exists and TABLE_SCHEMA is called OWNER instead) so i simply added a specific OracleSchemaService.cs, added it to the DatabaseMetadataService switch and wrote the correct functions to retrieve tables and views.

Now the program is able to open Oracle databases without throwing exceptions and dbinspector windows seems to work correctly with them.