### PR TITLE
Fix print cmd

### DIFF
--- a/src/ChangeLog.txt
+++ b/src/ChangeLog.txt
@@ -1,6 +1,7 @@
 Mini SQL Query Change Log
 =========================
 
+2016-01-28	FIX: Fix for the print dialog never showing up properly
 2015-01-23	ENH: Improved the View Table screen with better default columns sizes and remembers it between executions
 2015-01-22	ENH: Added a "Cancel" implementation - provider specific of course!
 2015-01-21	FIX: Fixed issue where template host not creating data object

--- a/src/MiniSqlQuery.Core/Commands/PrintCommand.cs
+++ b/src/MiniSqlQuery.Core/Commands/PrintCommand.cs
@@ -64,6 +64,9 @@ namespace MiniSqlQuery.Core.Commands
 					{
 						ppd.Document = doc;
 						ppd.AllowSomePages = true;
+						// https://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k(System.Windows.Forms.PrintDialog.UseEXDialog);k(TargetFrameworkMoniker-.NETFramework,Version%3Dv3.5);k(DevLang-csharp)&rd=true#Anchor_1
+						ppd.AllowSomePages = true;
+						
 						if (ppd.ShowDialog(HostWindow.Instance) == DialogResult.OK)
 						{
 							doc.Print();

--- a/src/MiniSqlQuery.Core/Properties/AssemblyInfo.cs
+++ b/src/MiniSqlQuery.Core/Properties/AssemblyInfo.cs
@@ -11,7 +11,7 @@ using System.Reflection;
 [assembly: AssemblyTitle("Mini SQL Query Core Services and Interfaces")]
 [assembly: AssemblyDescription("A Mini SQL Query Core interfaces and classes.")]
 [assembly: AssemblyProduct("MiniSqlQuery.Core")]
-[assembly: AssemblyVersion("1.15.01.23")]
-[assembly: AssemblyFileVersion("1.15.01.23")]
+[assembly: AssemblyVersion("1.16.01.28")]
+[assembly: AssemblyFileVersion("1.16.01.28")]
 
 // see also CommonAssemblyInfo.cs 

--- a/src/MiniSqlQuery/Properties/AssemblyInfo.cs
+++ b/src/MiniSqlQuery/Properties/AssemblyInfo.cs
@@ -14,7 +14,7 @@ using System.Reflection;
 	"The goal of the Mini SQL Query tool is to allow a developer or trouble-shooter to quickly diagnose issues or make changes to a database using a tool with a small footprint, that is fast and easy to use."
 	)]
 [assembly: AssemblyProduct("MiniSqlQuery")]
-[assembly: AssemblyVersion("1.15.01.23")]
-[assembly: AssemblyFileVersion("1.15.01.23")]
+[assembly: AssemblyVersion("1.16.01.28")]
+[assembly: AssemblyFileVersion("1.16.01.28")]
 
 // see also CommonAssemblyInfo.cs


### PR DESCRIPTION
Interesting one.

The print dialog was returning with "Cancel" before showing anything. The "fix" (or is that a workaround) is to set the `PrintDialog.UseEXDialog` value to `true`.

For more info see https://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k(System.Windows.Forms.PrintDialog.UseEXDialog);k(TargetFrameworkMoniker-.NETFramework,Version%3Dv3.5);k(DevLang-csharp)&rd=true

Thanks https://github.com/beboobailey `:-)`